### PR TITLE
Added the ability to Parse with tags from a copy-pasted links with tags.

### DIFF
--- a/README
+++ b/README
@@ -4,6 +4,8 @@ Find this extension on the Chrome webstore here - https://chrome.google.com/webs
 
 This extension is an add-on for Pocket, formerly Read It Later. It allows the user to add multiple links to their Pocket account at once, through the text they select on Chrome or by pasting links into the extension. All the hyperlinks/urls in the selected text are parsed by this extension. It is also possible to add common and custom tags to the selected links before sending them to Pocket.
 
+Pasting links with tags is possible too. After each link add a space and hashtag sign '#' followed by one or more tags (comma separated). If no tags needed for a certain link, a hash tag followed by space is still needed if 'Parse with tags' button is pressed.
+
 Dependencies - 
 Jquery
 Bootstrap 3

--- a/html/popup.html
+++ b/html/popup.html
@@ -68,6 +68,8 @@
 		<div class="input-group text-center">
 			<textarea rows="15" cols = "50" placeholder="Copy a list of valid urls/links seperated by whitespace here and click on Parse" id="links" required></textarea>
 	        <button type="button" class="btn btn-success" id = "parse-links">Parse</button>
+	        <big> &nbsp;&nbsp;&nbsp;&nbsp; </big>
+	        <button type="button" class="btn btn-success" id = "parse-links-with-tags">Parse with tags</button>
 		</div>
 		<p id="paste-error" class="bg-danger status"></p>
 	</div>

--- a/js/popup.js
+++ b/js/popup.js
@@ -19,6 +19,29 @@
 		$('.toggable').hide();
 		$('#link-content').show();
 	}
+	function buildLinksWithTags(links)
+	{
+		var urls = links.urls;
+		var titles = links.titles;
+		var tags = links.tags;
+		$('#no-link-content').hide();
+		$('#link-content').show();
+		var checkbox = '<input type="checkbox" checked>';
+		// var tag_input = '<input type = "text" style = "max-width:150px">';
+		for (var i=0; i<urls.length; i++)
+		{
+			var url = urls[i];
+			var tag_input = tags[i];
+			var title_input = '<input type = "text" style = "max-width:150px" value = "'+ titles[i] +'">';
+			var tag_input = '<input type = "text" style = "max-width:150px" value = "'+ tags[i] +'">';
+			var str = "<tr><td>" + (i+1) + "</td>" + "<td>" + checkbox +"</td>" +"<td>"+title_input+"</td>" +
+				"<td><a href = '" + url + "' target='_blank' >"  + url + "</a></td><td>" + tag_input + "</td></tr>";
+			$('#mytable > tbody').append(str);
+		}
+		$('.toggable').hide();
+		$('#link-content').show();
+	}
+
 	function single_submit_handler()
 	{
 		chrome.tabs.query({currentWindow: true, active: true}, function(tabs)
@@ -73,6 +96,10 @@
 	//taken from http://stackoverflow.com/questions/161738/what-is-the-best-regular-expression-to-check-if-a-string-is-a-valid-url
 	//the RegexBuddy answer
 	var regex =  /\b(https?|ftp|file):\/\/[\-A-Za-z0-9+&@#\/%?=~_|!:,.;]*[\-A-Za-z0-9+&@#\/%=~_|‌​]/gi;
+	//taken from https://stackoverflow.com/a/4564478/1970830
+	// But then modified until making it captures also # without following anything and inspired by the above regex to capture commas too
+	//don't want to grab '#' if it's embedded
+	var tags_regex = /(?:^|\s)(#[\-A-Za-z0-9+&@#\/%?=~_|!:,.;]*[\-A-Za-z0-9+&@#\/%=~_|‌]*\w*)/gi; //regex for finding text starts with hash #
 	function parse_submit_handler()
 	{
 		var text = $('#links').val();
@@ -90,6 +117,34 @@
 		var req = {"urls" : urls, "titles" : titles};
 		buildLinks(req);
 	}
+	function parse_with_tags_submit_handler()
+	{
+		var text = $('#links').val();
+		var urls = text.match(regex);
+		var tags = text.match(tags_regex);
+		if(!urls || urls.length === 0)
+		{
+			$('#paste-error').text('Please enter a valid list').show();
+			return;
+		}
+		if(urls.length != tags.length)
+		{
+			$('#paste-error').text('Please submit tags with equal number to links. If no tag wanted for a link, write only # without any tags after the link.').show();
+			return;
+		}
+		//remove the space + hash characters
+		for(var i = 0; i < tags.length; i++)
+		{
+		    tags[i] = tags[i].substring(2);
+		}
+		var titles = [];
+		for(var i = 0; i < urls.length; i++)
+		{
+			titles.push('');
+		}
+		var req = {"urls" : urls, "titles" : titles, "tags" : tags};
+		buildLinksWithTags(req);
+	}	
 	function logout_hander()
 	{
 		Auth.logout();
@@ -103,6 +158,7 @@
 		$('#submit-single-button').click(single_submit_handler);
 		$('#submit-button').click(submit_button_handler);
 		$('#parse-links').click(parse_submit_handler);
+		$('#parse-links-with-tags').click(parse_with_tags_submit_handler);
 		$('a#logout').click(logout_hander);
 		$('body').on('click', 'a.link', function(){  //set up hyperlinks in popup.html as chrome blocks them
     		chrome.tabs.create({url: $(this).attr('href')});


### PR DESCRIPTION
Pasting links with tags now is possible too. After each link add a space and hashtag sign '#' followed by one or more tags (comma separated). If no tags needed for a certain link, a hash tag followed by space is still needed if 'Parse with tags' button is pressed.